### PR TITLE
Fix make docker-push to work with docker.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,13 +74,14 @@ docker-push:
 		echo "Please define DOCKER_REPO_USER and DOCKER_REPO_PASS."; \
 		exit 1; \
 	else \
-		docker login --username=${DOCKER_REPO_USER} --password=${DOCKER_REPO_PASS} https://${DOCKER_REPO}; \
 		if [ ${DOCKER_REPO} = "docker.io" ]; then \
+			docker login --username=${DOCKER_REPO_USER} --password=${DOCKER_REPO_PASS} \
 			for i in $$(docker images --format '{{.Repository}}:{{.Tag}}' | grep ${DOCKER_NAMESPACE} | grep :${IMAGE_TAG} | grep -v '<none>'); do \
 				echo "docker push $$i"; \
 				docker push $$i; \
 			done; \
 		else \
+			docker login --username=${DOCKER_REPO_USER} --password=${DOCKER_REPO_PASS} https://${DOCKER_REPO}; \
 			for i in $$(docker images --format '{{.Repository}}:{{.Tag}}' | grep ${DOCKER_REPO}/${DOCKER_NAMESPACE} | grep :${IMAGE_TAG} | grep -v '<none>'); do \
 				echo "docker push $$i"; \
 				docker push $$i; \

--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,17 @@ docker-push:
 		exit 1; \
 	else \
 		docker login --username=${DOCKER_REPO_USER} --password=${DOCKER_REPO_PASS} https://${DOCKER_REPO}; \
-		for i in $$(docker images --format '{{.Repository}}:{{.Tag}}' | grep ${DOCKER_REPO}/${DOCKER_NAMESPACE} | grep :${IMAGE_TAG} | grep -v '<none>'); do \
-			echo "docker push $$i"; \
-			docker push $$i; \
-		done; \
+		if [ ${DOCKER_REPO} = "docker.io" ]; then \
+			for i in $$(docker images --format '{{.Repository}}:{{.Tag}}' | grep ${DOCKER_NAMESPACE} | grep :${IMAGE_TAG} | grep -v '<none>'); do \
+				echo "docker push $$i"; \
+				docker push $$i; \
+			done; \
+		else \
+			for i in $$(docker images --format '{{.Repository}}:{{.Tag}}' | grep ${DOCKER_REPO}/${DOCKER_NAMESPACE} | grep :${IMAGE_TAG} | grep -v '<none>'); do \
+				echo "docker push $$i"; \
+				docker push $$i; \
+			done; \
+		fi; \
 	fi;
 
 # TODO: setup-registry


### PR DESCRIPTION
By default DockerHub images use `namespace/image_name:tag` format. Thus, add new conditions to `make docker-push` to counter this bug.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

